### PR TITLE
[Modify] Type 오타 수정 및 latitudeDelta,longitudeDelta 기본값 수정

### DIFF
--- a/src/@types/map.d.ts
+++ b/src/@types/map.d.ts
@@ -39,10 +39,10 @@ declare global {
     | 'RTX'
     | 'NHO'
     | 'RTO'
-    | 'ETC';
+    | 'ETC'
+    | 'RTO';
 
   type OilStationType = {
-    | 'RTO';
     UNI_ID: string;
     POLL_DIV_CD: string;
     OS_NM: string;

--- a/src/components/Map/GoogleMap.tsx
+++ b/src/components/Map/GoogleMap.tsx
@@ -24,8 +24,8 @@ proj4.defs(
   '+proj=tmerc +lat_0=38 +lon_0=128 +k=0.9999 +x_0=400000 +y_0=600000 +ellps=bessel +units=m +no_defs +towgs84=-115.80,474.99,674.11,1.16,-2.31,-1.63,6.43',
 );
 
-const latitudeDelta = 0.025;
-const longitudeDelta = 0.025;
+const latitudeDelta = 0.04;
+const longitudeDelta = 0.04;
 
 function GoogleMap() {
   const mapRef = useRef<MapView>(null);
@@ -62,7 +62,6 @@ function GoogleMap() {
       return oilStation;
     });
   });
-
 
   const onRegionChangeComplete = (newRegion: Region) => {
     setRegion(newRegion);

--- a/src/components/Map/GoogleMap.tsx
+++ b/src/components/Map/GoogleMap.tsx
@@ -34,8 +34,8 @@ function GoogleMap() {
   const [region, setRegion] = useState<Region>({
     latitude: 37.564362,
     longitude: 126.977011,
-    latitudeDelta: 0.04864195044303443,
-    longitudeDelta: 0.040142817690068,
+    latitudeDelta,
+    longitudeDelta,
   });
   const tmToWgs = proj4(WGS84, TM128, [region.longitude, region.latitude]);
 


### PR DESCRIPTION
 1. git merge conflict 해결 도중 OilStationType 타입 오타 수정
 2. "내 위치로 이동" 버튼 클릭시, region에 latitudeDelta, longitudeDelta가 안맞는 현상이 발생되어, default value를 통일시켰습니다.