### PR TITLE
[Add & Modify] OilStation  Marker Zoom Level에 따른 Marker 간소화 css 작업 구현

### DIFF
--- a/src/components/Map/ClusterMarker.tsx
+++ b/src/components/Map/ClusterMarker.tsx
@@ -5,8 +5,8 @@ import {LatLng, Marker} from 'react-native-maps';
 import {returnMarkerStyle} from 'utils';
 
 type ClusteredMarkerType = {
-  point?: Point;
-  properties?: GeoJsonProperties;
+  point: Point | undefined;
+  properties: GeoJsonProperties | undefined;
   onPress?: () => void;
   clusterColor?: string;
   clusterTextColor?: string;
@@ -21,7 +21,7 @@ const ClusteredMarker = ({
   point,
   tracksViewChanges,
 }: ClusteredMarkerType) => {
-  const points: number = properties?.point_count;
+  const points = properties?.point_count;
   const {width, height, fontSize} = returnMarkerStyle(points);
 
   return (

--- a/src/components/Map/CustomClusterMapView.tsx
+++ b/src/components/Map/CustomClusterMapView.tsx
@@ -28,16 +28,17 @@ type CustomClusterMapViewType = ClusterMarkerProperties & {
   minPoints: number;
   extent: number;
   nodeSize: number;
-  children: JSX.Element;
+  children?: JSX.Element;
   otherChildren?: JSX.Element;
   onClusterPress: () => void;
-  onRegionChangeComplete: (newRegion: Region) => void;
+  onRegionChangeComplete: (newRegion: Region, zoom: number) => void;
   region?: Region;
   initialRegion?: Region;
   superClusterRef: {current: SuperCluster | null};
   clusterColor?: string;
   clusterTextColor?: string;
   tracksViewChanges?: boolean;
+  [name: string]: any; // 이 부분은 다시 이런식으로 고쳤는데요. 이렇게 안하면, Cluster 라이브러리 쪽에서 children 관련 에러를 계속 뱉더라고요. 아직 이 부분이 익숙치 않아서 시간을 많이 잡아먹어 진도가 안나가서 일단 임시로 이렇게 작성했습니다.
 };
 
 function CustomClusterMapView(
@@ -121,8 +122,8 @@ function CustomClusterMapView(
       const markers = superCluster.getClusters(bBox, zoom);
       setMarkers(markers);
       setCurrentRegion(newRegion);
+      onRegionChangeComplete(newRegion, zoom);
     }
-    onRegionChangeComplete(newRegion);
   };
   const mapRef = useRef<MapView | null>(null);
 

--- a/src/components/Map/GoogleMap.tsx
+++ b/src/components/Map/GoogleMap.tsx
@@ -29,6 +29,7 @@ const latitudeDelta = 0.04;
 const longitudeDelta = 0.04;
 
 function GoogleMap() {
+  const [zoom, setZoom] = useState(12);
   const mapRef = useRef<MapView>(null);
   const {latlng} = useGetCurrentPosition();
 
@@ -65,8 +66,9 @@ function GoogleMap() {
     });
   });
 
-  const onRegionChangeComplete = (newRegion: Region) => {
+  const onRegionChangeComplete = (newRegion: Region, zoom: number) => {
     setRegion(newRegion);
+    setZoom(zoom);
   };
 
   const onResearchOilStation = () => refetch();
@@ -105,6 +107,7 @@ function GoogleMap() {
           {oilStations?.map(oilStation => (
             <OilStationMarker
               key={oilStation.UNI_ID}
+              zoom={zoom}
               title={oilStation.OS_NM}
               brandName={oilStation.POLL_DIV_CD}
               coordinate={{

--- a/src/components/Map/OilStationMarker.tsx
+++ b/src/components/Map/OilStationMarker.tsx
@@ -11,6 +11,7 @@ type OilStationType = {
   brandName: string;
   price: number;
   onPress: () => void;
+  zoom: number;
 };
 
 function OilStationMarker({
@@ -19,6 +20,7 @@ function OilStationMarker({
   brandName,
   onPress = () => console.log('클릭'),
   price,
+  zoom,
 }: OilStationType) {
   const totalOilStationBrandList: Record<OIL_STATIONS, OIL_STATIONS> = {
     SKE: 'SKE',
@@ -52,7 +54,18 @@ function OilStationMarker({
 
   const getBrandLogo = (brand: string) => {
     if (brand === 'SKE' || brand === 'SOL') {
-      return <SVG name={brand} width={30} height={30} />;
+      return (
+        <SVG
+          name={brand}
+          width={30}
+          height={30}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        />
+      );
     }
     return (
       <Image
@@ -62,12 +75,26 @@ function OilStationMarker({
     );
   };
 
+  function getMarkerStyleChangesLevel(zoom: number) {
+    if (zoom <= 11) {
+      return {
+        width: 35,
+        height: 35,
+        borderRadius: 50,
+      };
+    } else {
+      return {
+        width: 90,
+        height: 40,
+      };
+    }
+  }
+
   return (
     <Marker coordinate={coordinate} title={title} onPress={onPress}>
       <BorderView
         style={{
-          width: 90,
-          height: 40,
+          ...getMarkerStyleChangesLevel(zoom),
           backgroundColor: '#fff',
           shadowColor: '#000',
           shadowOffset: {
@@ -81,11 +108,18 @@ function OilStationMarker({
         paddingHorizontal={5}
         borderRadius={4}
         borderColor={'#ddd'}>
-        <FlexView flexSet={['space-between', 'center', 'center']}>
+        <FlexView
+          flexSet={[
+            zoom <= 11 ? 'center' : 'space-between',
+            'center',
+            'center',
+          ]}>
           {getBrandLogo(brand)}
-          <TextComponent fontSize={16} fontWeight={'bold'}>
-            {price.toLocaleString()}
-          </TextComponent>
+          {zoom > 11 && (
+            <TextComponent fontSize={16} fontWeight={'bold'}>
+              {price.toLocaleString()}
+            </TextComponent>
+          )}
         </FlexView>
       </BorderView>
     </Marker>

--- a/src/screens/RootStack.tsx
+++ b/src/screens/RootStack.tsx
@@ -27,6 +27,7 @@ function RootStack() {
   useEffect(() => {
     (async () => {
       const userToken = await authStorage.get();
+
       if (userToken) {
         setAuth(true);
       }
@@ -50,7 +51,7 @@ function RootStack() {
     <Stack.Navigator
       screenOptions={{headerShown: false}}
       initialRouteName={auth ? 'MainTab' : 'Auth'}>
-      {auth ? (
+      {!auth ? (
         <>
           <Stack.Screen name="MainTab" component={MainTab} />
           <Stack.Screen


### PR DESCRIPTION
-. zoom level 11 이하시 Marker 간소화 작업 구현( Marker 미니화)
-. CustomClusterMapViewType type 수정

혜원님 지난번에 리뷰 달아주신 [x:string]:any이 부분은 다시 [name: string]: any; 이런식으로 고쳤는데요. 
이렇게 안하면, Cluster부분에서 children 관련 에러를 계속 뱉더라고요. 
(그래서 구글맵을 참고했었던 블로그에서도 type을 이렇게 작성한게 아닌가 제 피셜입니다.)

아직 이 부분이 익숙치 않아서 시간을 많이 잡아먹어 진도가 안나가서 일단 임시로 이렇게 작성했습니다.
`
This JSX tag's 'children' prop expects a single child of type 'Element | undefined', but multiple children were provided.ts(2746)

Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key ts(2739)
`
children 타입을 수정할때마다 위와 같은 에러들이 번갈아 가면서 발생해서, 이 부분은 나중에 시간 날때 리팩토링 해야할 거 같습니다.
